### PR TITLE
Added state transition to go to IDLE when the CONCLUDE sweep event is…

### DIFF
--- a/include/states.h
+++ b/include/states.h
@@ -33,6 +33,14 @@ enum State {
 	SWEEP_STATE,
 };
 
+std::unordered_map<State, std::string> stateWords = {
+	{IDLE_STATE     , "IDLE"}     ,
+	{EXPLORE_STATE  , "EXPLORE"}  ,
+	{INPUT_STATE    , "INPUT"}    ,
+	{APPROACH_STATE , "APPROACH"} ,
+	{SWEEP_STATE    , "SWEEP"}
+};
+
 void
 resetEvents(const std::string event, bool value = false)
 {

--- a/src/executive/executive.cpp
+++ b/src/executive/executive.cpp
@@ -48,6 +48,7 @@ BehavioralExecutive::run()
     {	
         stateMsg.data = currentState;
         statePub_.publish(stateMsg);
+		ROS_INFO_STREAM("Changed state from " << stateWords[oldState] << ", to " << stateWords[currentState] << std::endl);
     }
 }
 

--- a/src/executive/executive.cpp
+++ b/src/executive/executive.cpp
@@ -244,7 +244,7 @@ BehavioralExecutive::runSweep()
     }
 
     /* Transition to Explore */
-    if (eventDict[NO_HUMAN] and not eventDict[USER_CONTROL])
+    if (eventDict[NO_HUMAN] and not eventDict[USER_CONTROL] and not eventDict[CONCLUDE_SWEEP])
     {
         ros::Duration(2.0).sleep();
         currentState = EXPLORE_STATE;
@@ -261,6 +261,7 @@ BehavioralExecutive::runSweep()
 		/* Reset the concluding event */
 		resetEvents(CONCLUDE_SWEEP);
 		/* Go to IDLE */
+        ros::Duration(2.0).sleep();
 		currentState = IDLE_STATE;
 	}
 

--- a/src/executive/executive.cpp
+++ b/src/executive/executive.cpp
@@ -255,6 +255,14 @@ BehavioralExecutive::runSweep()
     /* Transition to Idle */
     if (eventDict[STOP]) currentState = IDLE_STATE;
 
+	/* Perform the concluding switch to idle */
+	if (eventDict[NO_HUMAN] and eventDict[CONCLUDE_SWEEP]) {
+		/* Reset the concluding event */
+		resetEvents(CONCLUDE_SWEEP);
+		/* Go to IDLE */
+		currentState = IDLE_STATE;
+	}
+
     finishedSweepSleep_ = true;
 }
 


### PR DESCRIPTION
1. Send START we transition from IDLE to EXPLORE
![image](https://user-images.githubusercontent.com/29968424/139865682-679cdde0-7108-452b-a724-945f8e1eb380.png)

2. Send GOAL REACHED we transition from EXPLORE to SWEEP
3. Now test normal case: send NO HUMAN and transition back to EXPLORE
![image](https://user-images.githubusercontent.com/29968424/139865907-2d6f46d6-a2ca-48a1-bd10-826da796d090.png)

4. Now to test the conclusion case. Need to set two events, GOAL REACHED and CONCLUDE SWEEP. After setting these two events we transition to SWEEP

5. And finally now when we set NO HUMAN, we transition to IDLE
![image](https://user-images.githubusercontent.com/29968424/139866166-698e185a-6154-4d62-b44b-b60f856e2ff4.png)
